### PR TITLE
supdev Pm7VCxZ6 - Use Dotenv gem to load Braintree credentials.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.rbc
 capybara-*.html
 .rspec
+.env
 /log
 /tmp
 /db/*.sqlite3

--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ gem 'sdoc', '~> 0.4.0', group: :doc
 
 gem 'braintree', '~> 2.47'
 
+gem 'dotenv', '~> 2.0'
+
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,6 +52,7 @@ GEM
     coffee-script-source (1.9.1.1)
     debug_inspector (0.0.2)
     diff-lcs (1.2.5)
+    dotenv (2.0.2)
     erubis (2.7.0)
     execjs (2.6.0)
     globalid (0.3.6)
@@ -162,6 +163,7 @@ DEPENDENCIES
   braintree (~> 2.47)
   byebug
   coffee-rails (~> 4.1.0)
+  dotenv (~> 2.0)
   jbuilder (~> 2.0)
   jquery-rails
   rails (= 4.2.4)

--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ An example Braintree integration for Ruby on Rails
 2. Bundle
   `bundle`
 
-3. Add your Braintree API credentials to `config/initializers/braintree.rb`
-   Credentials can be found by navigating to Account > My user > View API Keys in the Braintree control panel.
+3. Copy the `example.env` file to `.env` and fill in your Braintree API credentials
+   Credentials can be found by navigating to Account > My user > View API Keys in the Braintree control panel. Full instructions can be [found on our support site](https://articles.braintreepayments.com/control-panel/important-gateway-credentials#api-credentials).
 
 4. Start rails
    `rails server`
@@ -32,7 +32,6 @@ You can run both unit and integrations tests by calling `rake spec` on the comma
 
 ## Pro Tips
 
- * Run `git update-index --assume-unchanged config/initializers/braintree.rb` to prevent yourself from committing your Braintree credentials.
  * Run `rails s -b 0.0.0.0` when launching Rails server to listen on all interfaces.
 
 ## Disclaimer

--- a/config/initializers/braintree.rb
+++ b/config/initializers/braintree.rb
@@ -1,8 +1,6 @@
-# Your should not store your Braintree credentials in source code. This is done for demonstration purposes.
+Dotenv.load
 
-# Instructions for accessing your api credentials can be found at:
-# https://articles.braintreepayments.com/control-panel/important-gateway-credentials#api-credentials
-Braintree::Configuration.environment = :sandbox
-Braintree::Configuration.merchant_id = "use_your_merchant_id"
-Braintree::Configuration.public_key  = "use_your_public_key"
-Braintree::Configuration.private_key = "use_your_private_key"
+Braintree::Configuration.environment = ENV["BT_ENVIRONMENT"].to_sym
+Braintree::Configuration.merchant_id = ENV["BT_MERCHANT_ID"]
+Braintree::Configuration.public_key  = ENV["BT_PUBLIC_KEY"]
+Braintree::Configuration.private_key = ENV["BT_PRIVATE_KEY"]

--- a/example.env
+++ b/example.env
@@ -1,0 +1,4 @@
+BT_ENVIRONMENT='sandbox'
+BT_MERCHANT_ID='your braintree merchant id'
+BT_PUBLIC_KEY='your braintree public key'
+BT_PRIVATE_KEY='your braintree private key'


### PR DESCRIPTION
We should have the users store their Braintree credentials in an `.env` file instead of inline in the source code. This updates the example to use `Dotenv` instead.
