### PR TITLE
Change regex to not match on 'new'

### DIFF
--- a/spec/integration/controllers/checkouts_controller_spec.rb
+++ b/spec/integration/controllers/checkouts_controller_spec.rb
@@ -47,7 +47,7 @@ RSpec.describe CheckoutsController, type: :controller do
       amount = "#{random.rand(100)}.#{random.rand(100)}"
       post :create, payment_method_nonce: "fake-valid-nonce", amount: amount
 
-      expect(response).to redirect_to(/\/checkouts\/\w+/)
+      expect(response).to redirect_to(/\/checkouts\/[^new$][\w+]/)
     end
 
     context "when transaction is not succesful" do


### PR DESCRIPTION
### Problem

Currently, this test is a false positive, since redirected to `/new` would indicate there was an error, but it still matches the current regex.
### Solution

Exclude `new` from the regex
