### PR TITLE
Handle processor and gateway rejection error responses

### DIFF
--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -18,6 +18,9 @@ class CheckoutsController < ApplicationController
 
     if result.success?
       redirect_to checkout_path(result.transaction.id)
+    elsif result.transaction
+      flash[:error] = "Transaction status - #{result.transaction.status}"
+      redirect_to checkout_path(result.transaction.id)
     else
       error_messages = result.errors.map { |error| "Error: #{error.code}: #{error.message}" }
       flash[:error] = error_messages

--- a/spec/controllers/checkouts_controller_spec.rb
+++ b/spec/controllers/checkouts_controller_spec.rb
@@ -71,6 +71,36 @@ RSpec.describe CheckoutsController, type: :controller do
       expect(response).to redirect_to("/checkouts/#{mock_transaction.id}")
     end
 
+    context "when there are processor errors" do
+      it "displays the transaction status" do
+        amount = "2000"
+        nonce = "fake-valid-nonce"
+
+        expect(Braintree::Transaction).to receive(:sale).with(
+          amount: amount,
+          payment_method_nonce: nonce,
+        ).and_return(processor_declined_result)
+
+        post :create, payment_method_nonce: nonce, amount: amount
+
+        expect(flash[:error]).to eq("Transaction status - processor_declined")
+      end
+
+      it "redirects to the transaction page" do
+        amount = "2000"
+        nonce = "fake-valid-nonce"
+
+        expect(Braintree::Transaction).to receive(:sale).with(
+          amount: amount,
+          payment_method_nonce: nonce,
+        ).and_return(processor_declined_result)
+
+        post :create, payment_method_nonce: nonce, amount: amount
+
+        expect(response).to redirect_to("/checkouts/#{processor_declined_result.transaction.id}")
+      end
+    end
+
     context "when braintree returns an error" do
       it "displays the errors" do
         amount = "not_a_valid_amount"

--- a/spec/integration/controllers/checkouts_controller_spec.rb
+++ b/spec/integration/controllers/checkouts_controller_spec.rb
@@ -50,8 +50,15 @@ RSpec.describe CheckoutsController, type: :controller do
       expect(response).to redirect_to(/\/checkouts\/[^new$][\w+]/)
     end
 
-    context "when transaction is not succesful" do
-      it "redirects to the new_checkout_path" do
+    context "when its unsuccessful" do
+      it "creates a transaction and displays status when there are processor errors" do
+        amount = "2000"
+        post :create, payment_method_nonce: "fake-valid-nonce", amount: amount
+
+        expect(response).to redirect_to(/\/checkouts\/[^new$][\w+]/)
+      end
+
+      it "redirects to the new_checkout_path when the transaction was invalid" do
         amount = "#{random.rand(100)}.#{random.rand(100)}"
         post :create, payment_method_nonce: "fake-consumed-nonce", amount: amount
 

--- a/spec/support/mock_data.rb
+++ b/spec/support/mock_data.rb
@@ -33,10 +33,18 @@ RSpec.shared_context 'mock_data' do
     double(Braintree::ErrorResult,
       success?: false,
       message: "Amount is an invalid format. Unknown payment_method_nonce.",
+      transaction: nil,
       errors: [
         OpenStruct.new(code: 81503, message: "Amount is an invalid format."),
         OpenStruct.new(code: 91565, message: "Unknown payment_method_nonce."),
        ]
+    )
+  }
+
+  let(:processor_declined_result) {
+    double(Braintree::ErrorResult,
+      success?: false,
+      transaction: OpenStruct.new(status: "processor_declined", id: "my_id"),
     )
   }
 end


### PR DESCRIPTION
In cases where a transaction is declined by the processor or rejected by the payments gateway, a transaction is created, but the error is depicted in the transaction status. In these cases, we continue to redirect the user to the transaction page, but highlight the transaction status to indicate that the transaction was not a success.
