### PR TITLE
Add Travis CI Configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+rvm:
+  - 2.0
+notifications:
+  email:
+    - external-ci-notifications+braintree_rails_example@getbraintree.com

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 # Braintree Rails Example
+
+[![Build Status](https://travis-ci.org/braintree/braintree_rails_example.svg?branch=master)](https://travis-ci.org/braintree/braintree_rails_example)
+
 An example Braintree integration for Ruby on Rails.
 
 ## Setup Instructions


### PR DESCRIPTION
This PR adds a Travis CI integration to publicly display that build status of master and to enforce passing specs for PR's.