### PR TITLE
add dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM ruby:2.3.1-onbuild
+
+RUN apt-get update
+
+RUN bundle install

--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,7 @@ gem 'uglifier', '>= 1.3.0'
 # Use CoffeeScript for .coffee assets and views
 gem 'coffee-rails', '~> 4.1.0'
 # See https://github.com/rails/execjs#readme for more supported runtimes
-# gem 'therubyracer', platforms: :ruby
+gem 'therubyracer', platforms: :ruby
 
 # Use jquery as the JavaScript library
 gem 'jquery-rails'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,6 +66,7 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.3)
+    libv8 (3.16.14.15)
     loofah (2.0.3)
       nokogiri (>= 1.5.9)
     mail (2.6.3)
@@ -111,6 +112,7 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rake (10.4.2)
     rdoc (4.2.0)
+    ref (2.0.0)
     rspec-core (3.3.2)
       rspec-support (~> 3.3.0)
     rspec-expectations (3.3.1)
@@ -138,7 +140,7 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    spring (1.3.6)
+    spring (1.7.2)
     sprockets (3.3.4)
       rack (~> 1.0)
     sprockets-rails (2.3.2)
@@ -146,6 +148,9 @@ GEM
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
     sqlite3 (1.3.11)
+    therubyracer (0.12.2)
+      libv8 (~> 3.16.14.0)
+      ref
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (1.4.1)
@@ -180,6 +185,13 @@ DEPENDENCIES
   sdoc (~> 0.4.0)
   spring
   sqlite3
+  therubyracer
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+
+RUBY VERSION
+   ruby 2.3.1p112
+
+BUNDLED WITH
+   1.12.5

--- a/bin/rails
+++ b/bin/rails
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 begin
-  load File.expand_path("../spring", __FILE__)
-rescue LoadError
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
 end
 APP_PATH = File.expand_path('../../config/application', __FILE__)
 require_relative '../config/boot'

--- a/bin/rake
+++ b/bin/rake
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 begin
-  load File.expand_path("../spring", __FILE__)
-rescue LoadError
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
 end
 require_relative '../config/boot'
 require 'rake'

--- a/bin/spring
+++ b/bin/spring
@@ -4,12 +4,12 @@
 # It gets overwritten when you run the `spring binstub` command.
 
 unless defined?(Spring)
-  require "rubygems"
-  require "bundler"
+  require 'rubygems'
+  require 'bundler'
 
-  if match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m)
-    Gem.paths = { "GEM_PATH" => [Bundler.bundle_path.to_s, *Gem.path].uniq }
-    gem "spring", match[1]
-    require "spring/binstub"
+  if (match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m))
+    Gem.paths = { 'GEM_PATH' => [Bundler.bundle_path.to_s, *Gem.path].uniq.join(Gem.path_separator) }
+    gem 'spring', match[1]
+    require 'spring/binstub'
   end
 end


### PR DESCRIPTION
 - Add a dockerfile to the example

In order to get it to play nicely with the `FROM ruby:2.3.1-onbuild` image a few small changes needed to be made.

 - Add `therubyracer` gem
`execjs` requires a javascript runtime in order to work.

 - Update spring to `1.7.2`
When running in the docker container IwWas getting a lot of warning messages. 
```
Array values in the parameter to `Gem.paths=` are deprecated.
Please use a String or nil.
An Array ({"GEM_PATH"=>["/usr/local/bundle"]}) was passed in from bin/rake:3:in `load'
```

The solution seemed to be updating `spring`, you can read summaries [here](https://github.com/rubygems/rubygems/issues/1551) and [here](http://stackoverflow.com/questions/37864054/rails-5-array-values-in-the-parameter-to-gem-paths-are-deprecated)