### PR TITLE
add dockerfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.0
+  - 2.3.1
 notifications:
   email:
     - external-ci-notifications+braintree_rails_example@getbraintree.com

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM ruby:2.3.1-onbuild
+
+RUN apt-get update && apt-get install -y build-essential nodejs
+
+ENV APP_HOME /braintree_rails_example
+RUN mkdir $APP_HOME
+WORKDIR $APP_HOME
+
+ADD Gemfile* $APP_HOME/
+RUN bundle install
+
+ADD . $APP_HOME

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,7 +138,7 @@ GEM
     sdoc (0.4.1)
       json (~> 1.7, >= 1.7.7)
       rdoc (~> 4.0)
-    spring (1.3.6)
+    spring (1.7.2)
     sprockets (3.3.4)
       rack (~> 1.0)
     sprockets-rails (2.3.2)
@@ -183,3 +183,9 @@ DEPENDENCIES
   turbolinks
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
+
+RUBY VERSION
+   ruby 2.3.1p112
+
+BUNDLED WITH
+   1.12.5

--- a/bin/rails
+++ b/bin/rails
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 begin
-  load File.expand_path("../spring", __FILE__)
-rescue LoadError
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
 end
 APP_PATH = File.expand_path('../../config/application', __FILE__)
 require_relative '../config/boot'

--- a/bin/rake
+++ b/bin/rake
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 begin
-  load File.expand_path("../spring", __FILE__)
-rescue LoadError
+  load File.expand_path('../spring', __FILE__)
+rescue LoadError => e
+  raise unless e.message.include?('spring')
 end
 require_relative '../config/boot'
 require 'rake'

--- a/bin/spring
+++ b/bin/spring
@@ -4,12 +4,12 @@
 # It gets overwritten when you run the `spring binstub` command.
 
 unless defined?(Spring)
-  require "rubygems"
-  require "bundler"
+  require 'rubygems'
+  require 'bundler'
 
-  if match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m)
-    Gem.paths = { "GEM_PATH" => [Bundler.bundle_path.to_s, *Gem.path].uniq }
-    gem "spring", match[1]
-    require "spring/binstub"
+  if (match = Bundler.default_lockfile.read.match(/^GEM$.*?^    (?:  )*spring \((.*?)\)$.*?^$/m))
+    Gem.paths = { 'GEM_PATH' => [Bundler.bundle_path.to_s, *Gem.path].uniq.join(Gem.path_separator) }
+    gem 'spring', match[1]
+    require 'spring/binstub'
   end
 end

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+version: '2'
+services:
+  web:
+    build: .
+    command: bin/rails server --port 4567 --binding 0.0.0.0
+    ports:
+      - "4567:4567"
+    volumes:
+      - .:/braintree_rails_example


### PR DESCRIPTION
# Add docker

In order to get it to play nicely with the `FROM ruby:2.3.1-onbuild` image a few small changes needed to be made.

 - Update spring to `1.7.2`

When running in the docker container I was getting a lot of warning messages. 

```
Array values in the parameter to `Gem.paths=` are deprecated.
Please use a String or nil.
An Array ({"GEM_PATH"=>["/usr/local/bundle"]}) was passed in from bin/rake:3:in `load'
```

The solution seemed to be updating `spring`, you can read summaries [here](https://github.com/rubygems/rubygems/issues/1551) and [here](http://stackoverflow.com/questions/37864054/rails-5-array-values-in-the-parameter-to-gem-paths-are-deprecated)

# How-to

 - Include your creds in a `.env` file
 - `docker-compose up`
 - navigate to `localhost:4567`