### PR TITLE
add submit for settlement by default

### DIFF
--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -25,6 +25,9 @@ class CheckoutsController < ApplicationController
     result = Braintree::Transaction.sale(
       amount: amount,
       payment_method_nonce: nonce,
+      :options => {
+        :submit_for_settlement => true
+      }
     )
 
     if result.success? || result.transaction

--- a/spec/controllers/checkouts_controller_spec.rb
+++ b/spec/controllers/checkouts_controller_spec.rb
@@ -87,6 +87,9 @@ RSpec.describe CheckoutsController, type: :controller do
       expect(Braintree::Transaction).to receive(:sale).with(
         amount: amount,
         payment_method_nonce: nonce,
+        :options => {
+          :submit_for_settlement => true
+        }
       ).and_return(
         Braintree::SuccessfulResult.new(transaction: mock_transaction)
       )
@@ -104,6 +107,9 @@ RSpec.describe CheckoutsController, type: :controller do
         expect(Braintree::Transaction).to receive(:sale).with(
           amount: amount,
           payment_method_nonce: nonce,
+          :options => {
+            :submit_for_settlement => true
+          }
         ).and_return(processor_declined_result)
 
         post :create, payment_method_nonce: nonce, amount: amount
@@ -120,6 +126,9 @@ RSpec.describe CheckoutsController, type: :controller do
         expect(Braintree::Transaction).to receive(:sale).with(
           amount: amount,
           payment_method_nonce: nonce,
+          :options => {
+            :submit_for_settlement => true
+          }
         ).and_return(sale_error_result)
 
         post :create, payment_method_nonce: nonce, amount: amount
@@ -137,6 +146,9 @@ RSpec.describe CheckoutsController, type: :controller do
         expect(Braintree::Transaction).to receive(:sale).with(
           amount: amount,
           payment_method_nonce: nonce,
+          :options => {
+            :submit_for_settlement => true
+          }
         ).and_return(sale_error_result)
 
         post :create, payment_method_nonce: nonce, amount: amount


### PR DESCRIPTION
## Submit transactions for settlement by default

Currently, transactions are not submitted for settlement on the checkouts page. This would submit them automatically. For people using this repository to test out Braintree, this is useful as they don't have to manually submit each transaction they make in sandbox.