### PR TITLE
Include note in README for those without BT credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ An example Braintree integration for Ruby on Rails.
   ```
 
 3. Copy the contents of `example.env` into a new file named `.env` and fill in your Braintree API credentials. Credentials can be found by navigating to Account > My User > View Authorizations in the Braintree Control Panel. Full instructions can be [found on our support site](https://articles.braintreepayments.com/control-panel/important-gateway-credentials#api-credentials).
+*Note:* These environment variables are needed to run this app, even if you do not have credentials.  Follow this step and leave the default values from `example.env` if you intend to work only with the unit tests.
 
 4. Start rails:
 
@@ -36,8 +37,7 @@ You can deploy this app directly to Heroku to see the app live. Skip the setup i
 
 ### Running Unit Tests
 
-Unit tests do not make API calls to Braintree and do not require Braintree credentials. You can run this project's unit tests by
-calling `rake` on the command line.
+Unit tests do not make API calls to Braintree and do not require Braintree credentials. You can run this project's unit tests by calling `rake` on the command line.  If you do not have credentials, you still need to set some environment variables.  Follow the instructions above to create a `.env` file.
 
 ### Running Integration Tests
 


### PR DESCRIPTION
# Summary
Wanted to include instructions for those who want to work with the app without credentials (i.e. running unit tests)

## Problem
The `README` says you don't need to have credentials to run unit tests, but when you run unit tests, you will get immediate errors:

```
Failure/Error: require File.expand_path('../../config/environment', __FILE__)

NoMethodError:
  undefined method `to_sym' for nil:NilClass
  Did you mean?  to_s
# ./config/initializers/braintree.rb:3:in `<top (required)>'
# /Users/codypalmer/.rvm/gems/ruby-2.3.1@braintree_rails_example/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:268:in `load'
# /Users/codypalmer/.rvm/gems/ruby-2.3.1@braintree_rails_example/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:268:in `block in load'
# /Users/codypalmer/.rvm/gems/ruby-2.3.1@braintree_rails_example/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:240:in `load_dependency'
# /Users/codypalmer/.rvm/gems/ruby-2.3.1@braintree_rails_example/gems/activesupport-4.2.10/lib/active_support/dependencies.rb:268:in `load'
```
## Solution
You don't need credentials, but the application is assuming you have _something_ in those environment variables.  `Activesupport` will pull in all the initializers, which includes `config/initializers/braintree.rb` once the application is initialized.  And good news, the default values in `example.env` have values that will satisfy the requirements for running unit tests.