### PR TITLE
Use an instantiated gateway object instead of static method calls

### DIFF
--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -10,11 +10,11 @@ class CheckoutsController < ApplicationController
   ]
 
   def new
-    @client_token = Braintree::ClientToken.generate
+    @client_token = gateway.client_token.generate
   end
 
   def show
-    @transaction = Braintree::Transaction.find(params[:id])
+    @transaction = gateway.transaction.find(params[:id])
     @result = _create_result_hash(@transaction)
   end
 
@@ -22,7 +22,7 @@ class CheckoutsController < ApplicationController
     amount = params["amount"] # In production you should not take amounts directly from clients
     nonce = params["payment_method_nonce"]
 
-    result = Braintree::Transaction.sale(
+    result = gateway.transaction.sale(
       amount: amount,
       payment_method_nonce: nonce,
       :options => {
@@ -55,5 +55,14 @@ class CheckoutsController < ApplicationController
         :message => "Your test transaction has a status of #{status}. See the Braintree API response and try again."
       }
     end
+  end
+
+  def gateway
+    @gateway ||= Braintree::Gateway.new(
+      :environment => ENV["BT_ENVIRONMENT"].to_sym,
+      :merchant_id => ENV["BT_MERCHANT_ID"],
+      :public_key => ENV["BT_PUBLIC_KEY"],
+      :private_key => ENV["BT_PRIVATE_KEY"],
+    )
   end
 end

--- a/config/initializers/braintree.rb
+++ b/config/initializers/braintree.rb
@@ -1,6 +1,1 @@
 Dotenv.load
-
-Braintree::Configuration.environment = ENV["BT_ENVIRONMENT"].to_sym
-Braintree::Configuration.merchant_id = ENV["BT_MERCHANT_ID"]
-Braintree::Configuration.public_key  = ENV["BT_PUBLIC_KEY"]
-Braintree::Configuration.private_key = ENV["BT_PRIVATE_KEY"]

--- a/spec/controllers/checkouts_controller_spec.rb
+++ b/spec/controllers/checkouts_controller_spec.rb
@@ -7,13 +7,13 @@ RSpec.describe CheckoutsController, type: :controller do
 
   describe "GET #new" do
     it "returns http success" do
-      expect(Braintree::ClientToken).to receive(:generate).and_return("your_client_token")
+      expect_any_instance_of(Braintree::ClientTokenGateway).to receive(:generate).and_return("your_client_token")
       get :new
       expect(response).to have_http_status(:success)
     end
 
     it "adds the Braintree client token to the page" do
-      expect(Braintree::ClientToken).to receive(:generate).and_return("your_client_token")
+      expect_any_instance_of(Braintree::ClientTokenGateway).to receive(:generate).and_return("your_client_token")
       get :new
       expect(response.body).to match /your_client_token/
     end
@@ -21,7 +21,7 @@ RSpec.describe CheckoutsController, type: :controller do
 
   describe "GET #show" do
     it "returns http success" do
-      expect(Braintree::Transaction).to receive(:find).with("my_id").and_return(mock_transaction)
+      expect_any_instance_of(Braintree::TransactionGateway).to receive(:find).with("my_id").and_return(mock_transaction)
 
       get :show, id: "my_id"
 
@@ -29,7 +29,7 @@ RSpec.describe CheckoutsController, type: :controller do
     end
 
     it "displays the transaction's fields" do
-      expect(Braintree::Transaction).to receive(:find).with("my_id").and_return(mock_transaction)
+      expect_any_instance_of(Braintree::TransactionGateway).to receive(:find).with("my_id").and_return(mock_transaction)
 
       get :show, id: "my_id"
 
@@ -54,7 +54,7 @@ RSpec.describe CheckoutsController, type: :controller do
     end
 
     it "populates result object with success for a succesful transaction" do
-      expect(Braintree::Transaction).to receive(:find).with("my_id").and_return(mock_transaction)
+      expect_any_instance_of(Braintree::TransactionGateway).to receive(:find).with("my_id").and_return(mock_transaction)
 
       get :show, id: "my_id"
 
@@ -67,7 +67,7 @@ RSpec.describe CheckoutsController, type: :controller do
 
 
     it "populates result object with failure for a failed transaction" do
-      expect(Braintree::Transaction).to receive(:find).with("my_id").and_return(mock_failed_transaction)
+      expect_any_instance_of(Braintree::TransactionGateway).to receive(:find).with("my_id").and_return(mock_failed_transaction)
 
       get :show, id: "my_id"
 
@@ -84,7 +84,7 @@ RSpec.describe CheckoutsController, type: :controller do
       amount = "10.00"
       nonce = "fake-valid-nonce"
 
-      expect(Braintree::Transaction).to receive(:sale).with(
+      expect_any_instance_of(Braintree::TransactionGateway).to receive(:sale).with(
         amount: amount,
         payment_method_nonce: nonce,
         :options => {
@@ -104,7 +104,7 @@ RSpec.describe CheckoutsController, type: :controller do
         amount = "2000"
         nonce = "fake-valid-nonce"
 
-        expect(Braintree::Transaction).to receive(:sale).with(
+        expect_any_instance_of(Braintree::TransactionGateway).to receive(:sale).with(
           amount: amount,
           payment_method_nonce: nonce,
           :options => {
@@ -123,7 +123,7 @@ RSpec.describe CheckoutsController, type: :controller do
         amount = "not_a_valid_amount"
         nonce = "not_a_valid_nonce"
 
-        expect(Braintree::Transaction).to receive(:sale).with(
+        expect_any_instance_of(Braintree::TransactionGateway).to receive(:sale).with(
           amount: amount,
           payment_method_nonce: nonce,
           :options => {
@@ -143,7 +143,7 @@ RSpec.describe CheckoutsController, type: :controller do
         amount = "not_a_valid_amount"
         nonce = "not_a_valid_nonce"
 
-        expect(Braintree::Transaction).to receive(:sale).with(
+        expect_any_instance_of(Braintree::TransactionGateway).to receive(:sale).with(
           amount: amount,
           payment_method_nonce: nonce,
           :options => {


### PR DESCRIPTION
Instantiating a gateway with merchant credentials supports a wider
range of authentication methods for all types of Braintree merchants.