### PR TITLE
Fix need for .env variables when runnin unit tests

### DIFF
--- a/app/controllers/checkouts_controller.rb
+++ b/app/controllers/checkouts_controller.rb
@@ -58,8 +58,10 @@ class CheckoutsController < ApplicationController
   end
 
   def gateway
+    env = ENV["BT_ENVIRONMENT"]
+
     @gateway ||= Braintree::Gateway.new(
-      :environment => ENV["BT_ENVIRONMENT"].to_sym,
+      :environment => env && env.to_sym,
       :merchant_id => ENV["BT_MERCHANT_ID"],
       :public_key => ENV["BT_PUBLIC_KEY"],
       :private_key => ENV["BT_PRIVATE_KEY"],


### PR DESCRIPTION
closes #29

Our readme says:

> Unit tests do not make API calls to Braintree and do not require Braintree credentials. You can run this project's unit tests by calling rake on the command line.

But the tests fail because the bt gw can't be instantiated.

These changes make it so that it no longer requires to have a valid .env file to run unit tests.