### PR TITLE
Integration test fixes

### DIFF
--- a/spec/integration/controllers/checkouts_controller_spec.rb
+++ b/spec/integration/controllers/checkouts_controller_spec.rb
@@ -16,10 +16,19 @@ RSpec.describe CheckoutsController, type: :controller do
   end
 
   describe "GET #show" do
+    let(:gateway) {
+      Braintree::Gateway.new(
+        :environment =>  ENV["BT_ENVIRONMENT"].to_sym,
+        :merchant_id => ENV["BT_MERCHANT_ID"],
+        :public_key => ENV["BT_PUBLIC_KEY"],
+        :private_key => ENV["BT_PRIVATE_KEY"],
+      )
+    }
+
     it "retrieves the Braintree transaction and displays its attributes" do
       # Using a random amount to prevent duplicate checking errors
       amount = "#{random.rand(100)}.#{random.rand(100)}"
-      result = Braintree::Transaction.sale(
+      result = gateway.transaction.sale(
         :amount => amount,
         :payment_method_nonce => "fake-valid-nonce",
       )

--- a/spec/integration/controllers/checkouts_controller_spec.rb
+++ b/spec/integration/controllers/checkouts_controller_spec.rb
@@ -65,8 +65,8 @@ RSpec.describe CheckoutsController, type: :controller do
         amount = "2000"
         post :create, payment_method_nonce: "fake-valid-nonce", amount: amount
 
-      expect(response).not_to redirect_to(new_checkout_path)
-      expect(response).to redirect_to(/\/checkouts\/[\w+]/)
+        expect(response).not_to redirect_to(new_checkout_path)
+        expect(response).to redirect_to(/\/checkouts\/[\w+]/)
       end
 
       it "redirects to the new_checkout_path when the transaction was invalid" do

--- a/spec/integration/controllers/checkouts_controller_spec.rb
+++ b/spec/integration/controllers/checkouts_controller_spec.rb
@@ -56,15 +56,17 @@ RSpec.describe CheckoutsController, type: :controller do
       amount = "#{random.rand(100)}.#{random.rand(100)}"
       post :create, payment_method_nonce: "fake-valid-nonce", amount: amount
 
-      expect(response).to redirect_to(/\/checkouts\/[^new$][\w+]/)
+      expect(response).not_to redirect_to(new_checkout_path)
+      expect(response).to redirect_to(/\/checkouts\/[\w+]/)
     end
 
-    context "when its unsuccessful" do
+    context "when it's unsuccessful" do
       it "creates a transaction and displays status when there are processor errors" do
         amount = "2000"
         post :create, payment_method_nonce: "fake-valid-nonce", amount: amount
 
-        expect(response).to redirect_to(/\/checkouts\/[^new$][\w+]/)
+      expect(response).not_to redirect_to(new_checkout_path)
+      expect(response).to redirect_to(/\/checkouts\/[\w+]/)
       end
 
       it "redirects to the new_checkout_path when the transaction was invalid" do


### PR DESCRIPTION
Fixes for a few issues in the integration checkouts_controller spec:

- the `#show` test cannot run because the `Braintree::Gateway` hasn't been configured.
- the `#create` test will fail if the test happens to create a transaction that starts with the letter `n`.