### PR TITLE
Add missing Listen gem for development environment & update travis bundle

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: ruby
 rvm:
   - 2.3.1
+before_install:
+  - gem update --system
+  - gem install bundler
 notifications:
   email:
     - external-ci-notifications+braintree_rails_example@getbraintree.com

--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,9 @@ group :development do
   # Access an IRB console on exception pages or by using <%= console %> in views
   gem 'web-console', '~> 2.0'
 
+  # The Listen gem listens to file modifications and notifies you about the changes.
+  gem 'listen', '~> 3.1', '>= 3.1.5'
+
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,10 @@ GEM
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
     json (1.8.6)
+    listen (3.1.5)
+      rb-fsevent (~> 0.9, >= 0.9.4)
+      rb-inotify (~> 0.9, >= 0.9.7)
+      ruby_dep (~> 1.2)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -90,7 +94,7 @@ GEM
     mini_mime (1.0.1)
     mini_portile2 (2.4.0)
     minitest (5.11.3)
-    msgpack (1.2.4)
+    msgpack (1.2.10)
     multi_json (1.13.1)
     nio4r (2.3.1)
     nokogiri (1.10.2)
@@ -154,6 +158,7 @@ GEM
       rspec-mocks (~> 3.8.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.0)
+    ruby_dep (1.5.0)
     sass (3.7.3)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -208,6 +213,7 @@ DEPENDENCIES
   dotenv (~> 2.0)
   jbuilder (~> 2.0)
   jquery-rails
+  listen (~> 3.1, >= 3.1.5)
   pg (~> 0.21.0)
   rails (= 5.2.2.1)
   rails-controller-testing
@@ -222,4 +228,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   1.16.6
+   2.0.1


### PR DESCRIPTION
Add missing development dependency

The following error was thrown:

```
gems/bootsnap-1.3.2/lib/bootsnap/load_path_cache/core_ext/kernel_require.rb:32:in `require': Could not load the 'listen' gem. Add `gem 'listen'` to the development group of your Gemfile (LoadError)
```