### PR TITLE
Update bundler version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -228,4 +228,4 @@ DEPENDENCIES
   web-console (~> 2.0)
 
 BUNDLED WITH
-   2.0.1
+   2.0.2


### PR DESCRIPTION
When attempting to deploy the app to Heroku using the link in the readme, I got the following error:

```
-----> Detecting rake tasks
 !
 !     Could not detect rake tasks
 !     ensure you can run `$ bundle exec rake -P` against your app
 !     and using the production group of your Gemfile.
 !     Activating bundler (2.0.1) failed:
 !     Could not find 'bundler' (2.0.1) required by your /tmp/build_eac1be9a0f08a1f16b790dfce18c7f30/Gemfile.lock.
 !     To update to the latest version installed on your system, run `bundle update --bundler`.
 !     To install the missing version, run `gem install bundler:2.0.1`
 !     Checked in 'GEM_PATH=vendor/bundle/ruby/2.5.0', execute `gem env` for more information
 !     
 !     To install the version of bundler this project requires, run `gem install bundler -v '2.0.1'`
```

Based on some Heroku documentation, it looks like this is due to Heroku locking in their version of bundler per ruby buildpack:

https://devcenter.heroku.com/articles/bundler-version
https://devcenter.heroku.com/articles/ruby-support#libraries

Tested by deploying manually to heroku.