### PR TITLE
Update Dockerfile ruby version from 2.3.1 to 2.7.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.3.1-onbuild
+FROM ruby:2.7.4
 
 RUN apt-get update && apt-get install -y build-essential nodejs
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,9 +92,13 @@ GEM
       nokogiri (~> 1)
       rake
     mini_mime (1.1.2)
+    mini_portile2 (2.6.1)
     minitest (5.14.4)
     msgpack (1.4.2)
     nio4r (2.5.8)
+    nokogiri (1.12.5)
+      mini_portile2 (~> 2.6.1)
+      racc (~> 1.4)
     nokogiri (1.12.5-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
@@ -199,6 +203,7 @@ GEM
     websocket-extensions (0.1.5)
 
 PLATFORMS
+  ruby
   x86_64-darwin-20
   x86_64-linux
 


### PR DESCRIPTION
The project doesn't build with docker-compose:
```
 > [4/7] RUN bundle install:
#8 0.968 You must use Bundler 2 or greater with this lockfile.
------
executor failed running [/bin/sh -c bundle install]: exit code: 20
ERROR: Service 'web' failed to build : Build failed
```
Updating the Dockerfile to match the `.ruby-version`.